### PR TITLE
Add API key request and response schemas

### DIFF
--- a/api/schemas.py
+++ b/api/schemas.py
@@ -2,6 +2,37 @@ from pydantic import BaseModel, Field
 from typing import Optional
 from datetime import datetime
 
+# ---------------------------------------------------------------------------
+# API key schemas
+# ---------------------------------------------------------------------------
+# Added for GitHub Issue #40: "API Parameters - 4".
+# These schemas support future API-key validation endpoints by defining:
+# - APIKeyCreate: request body containing the API key string.
+# - APIKeyResponse: response body showing whether the key is valid and
+#   which AI provider it belongs to.
+# This is a schema-only change and does not modify existing routes or logic.
+
+
+class APIKeyCreate(BaseModel):
+    key_string: str = Field(
+        ...,
+        min_length=1,
+        max_length=256,
+        description="The API Key string",
+    )
+
+
+class APIKeyResponse(BaseModel):
+    is_valid: bool = Field(
+        ...,
+        description="Whether the API key is currently validated",
+    )
+    provider: str = Field(
+        default="Unknown",
+        description="The AI Provider",
+    )
+
+    
 class CoverLetterCreate(BaseModel):
     content: str = Field(..., min_length=1, description="Cover letter content")
     status: str = Field(default="draft", description="Status: draft or finalized")


### PR DESCRIPTION
## Summary

Closes #40

Added API key Pydantic schemas in `api/schemas.py`:

- `APIKeyCreate`
  - `key_string`
  - `min_length=1`
  - `max_length=256`

- `APIKeyResponse`
  - `is_valid`
  - `provider`, defaulting to `"Unknown"`

This is a schema-only change and does not modify existing routes or service logic.

## Testing

- `python -m compileall api`
- `pytest`

Result: `32 passed, 1 warning`