### PR TITLE
Fix: Restrict CoverLetterCreate status field to literal values

### DIFF
--- a/api/schemas.py
+++ b/api/schemas.py
@@ -1,5 +1,5 @@
 from pydantic import BaseModel, Field
-from typing import Optional
+from typing import Optional, Literal
 from datetime import datetime
 
 # ---------------------------------------------------------------------------
@@ -35,7 +35,7 @@ class APIKeyResponse(BaseModel):
     
 class CoverLetterCreate(BaseModel):
     content: str = Field(..., min_length=1, description="Cover letter content")
-    status: str = Field(default="draft", description="Status: draft or finalized")
+    status: Literal["draft", "finalized"] = Field(default="draft", description="Status: draft or finalized")
     template_version: str = Field(default="1.0", description="Template version")
 
 class CoverLetterUpdate(BaseModel):
@@ -44,7 +44,7 @@ class CoverLetterUpdate(BaseModel):
 class CoverLetterResponse(BaseModel):
     id: str
     content: str
-    status: str
+    status: Literal["draft", "finalized"]
     template_version: str
 
 class JobDescriptionCreate(BaseModel):


### PR DESCRIPTION
This PR resolves issue #39 by restricting the `status` field in the API schemas to only accept valid literal values.

## Changes
- Imported `Literal` from the `typing` module in `api/schemas.py`
- Updated `CoverLetterCreate.status` type from `str` to `Literal["draft", "finalized"]`
- Updated `CoverLetterResponse.status` type from `str` to `Literal["draft", "finalized"]`

## Why
This change ensures that the `status` field only accepts valid values (`"draft"` or `"finalized"`), preventing arbitrary strings from being passed to the API and improving type safety.

## Testing
Pydantic validation will now automatically reject any status values other than `"draft"` or `"finalized"`.

## Closes
Closes #39