### PR TITLE
Feature/issue 38 max length job description

### DIFF
--- a/api/schemas.py
+++ b/api/schemas.py
@@ -52,6 +52,7 @@ class JobDescriptionCreate(BaseModel):
 
 class JobDescriptionUpdate(BaseModel):
     text: str = Field(..., min_length=1, max_length=6000, description="Updated job description")
+
 class JobDescriptionResponse(BaseModel):
     id: str
     text: str

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -48,11 +48,10 @@ class CoverLetterResponse(BaseModel):
     template_version: str
 
 class JobDescriptionCreate(BaseModel):
-    text: str = Field(..., min_length=1, description="Job description text")
+    text: str = Field(..., min_length=1, max_length=6000, description="Job description text")
 
 class JobDescriptionUpdate(BaseModel):
-    text: str = Field(..., min_length=1, description="Updated job description")
-
+    text: str = Field(..., min_length=1, max_length=6000, description="Updated job description")
 class JobDescriptionResponse(BaseModel):
     id: str
     text: str


### PR DESCRIPTION
## Summary
Enforces a maximum character limit of 6000 on the `text` field for `JobDescriptionCreate` and `JobDescriptionUpdate` schemas, as required by the System Requirements Document.

## Changes
- Added `max_length=6000` to the `text` field in `JobDescriptionCreate`
- Added `max_length=6000` to the `text` field in `JobDescriptionUpdate`

This brings `JobDescription` in line with the existing `ResumeCreate` and `ResumeUpdate` schemas, which already enforce the same limit.

## Testing
Ran `pytest tests/ -v` — all tests pass.

Closes #38